### PR TITLE
Multi-column L4-L2 experiments

### DIFF
--- a/htmresearch/algorithms/column_pooler.py
+++ b/htmresearch/algorithms/column_pooler.py
@@ -252,11 +252,6 @@ class ColumnPooler(object):
       self.numActiveColumnsPerInhArea
     )
 
-    print
-    print len(lateralInput), sorted(list(lateralInput))
-    print len(self.activeCells), sorted(list(self.activeCells))
-    print
-
     # Update predictive cells for next time step
     self.tm.compute(activeColumns=self.activeCells,
                     activeExternalCells=lateralInput,

--- a/htmresearch/algorithms/column_pooler.py
+++ b/htmresearch/algorithms/column_pooler.py
@@ -252,6 +252,11 @@ class ColumnPooler(object):
       self.numActiveColumnsPerInhArea
     )
 
+    print
+    print len(lateralInput), sorted(list(lateralInput))
+    print len(self.activeCells), sorted(list(self.activeCells))
+    print
+
     # Update predictive cells for next time step
     self.tm.compute(activeColumns=self.activeCells,
                     activeExternalCells=lateralInput,

--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -455,7 +455,7 @@ class L4L2Experiment(object):
       "permanenceDecrement": 0.02,
       "minThreshold": 10,
       "predictedSegmentDecrement": 0.004,
-      "activationThreshold": 10,
+      "activationThreshold": 13,
       "maxNewSynapseCount": 20,
       "monitor": 0,
       "implementation": "cpp",
@@ -481,7 +481,7 @@ class L4L2Experiment(object):
       "initialProximalPermanence": 0.6,
       "minThreshold": 10,
       "predictedSegmentDecrement": 0.004,
-      "activationThreshold": 10,
+      "activationThreshold": 13,
       "maxNewSynapseCount": 20,
     }
 

--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -208,7 +208,7 @@ class L4L2Experiment(object):
       self.objectL2Representations[object] = self.getL2Representations()
 
       # send reset signal
-      self._sendResetSignal()
+      self.sendResetSignal()
 
 
   def infer(self, inferenceConfig, noise=None):
@@ -231,7 +231,7 @@ class L4L2Experiment(object):
     patterns, can be given.
     """
     self._unsetLearningMode()
-    self._sendResetSignal()
+    self.sendResetSignal()
 
     statistics = collections.defaultdict(list)
     objectID = inferenceConfig["object"]
@@ -255,7 +255,7 @@ class L4L2Experiment(object):
       self._updateInferenceStats(statistics, objectID)
 
     # send reset signal
-    self._sendResetSignal()
+    self.sendResetSignal()
 
     # save statistics
     statistics["numSteps"] = numSteps
@@ -486,6 +486,16 @@ class L4L2Experiment(object):
     }
 
 
+  def sendResetSignal(self, sequenceId=0):
+    """
+    Sends a reset signal to the network.
+    """
+    for col in xrange(self.numColumns):
+      self.sensorInputs[col].addResetToQueue(sequenceId)
+      self.externalInputs[col].addResetToQueue(sequenceId)
+    self.network.run(1)
+
+
   def _unsetLearningMode(self):
     """
     Unsets the learning mode, to start inference.
@@ -552,15 +562,6 @@ class L4L2Experiment(object):
       self.externalInputs[col].addDataToQueue(
         list(location), int(reset), sequenceId
       )
-
-
-  def _sendResetSignal(self):
-    """
-    Sends a reset signal to the network.
-    """
-    for col in xrange(self.numColumns):
-      self.L4Columns[col].reset()
-      self.L2Columns[col].reset()
 
 
   def _addNoise(self, pattern, noiseLevel):

--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -234,7 +234,10 @@ class L4L2Experiment(object):
 
     statistics = collections.defaultdict(list)
     objectID = inferenceConfig["object"]
-    numSteps = inferenceConfig["numSteps"]
+    if "numSteps" in inferenceConfig:
+      numSteps = inferenceConfig["numSteps"]
+    else:
+      numSteps = len(inferenceConfig["pairs"][0])
 
     # some checks
     if numSteps == 0:
@@ -251,10 +254,11 @@ class L4L2Experiment(object):
       self._updateInferenceStats(statistics, objectID)
 
     # send reset signal
-    self._sendResetSignal()
+    # self._sendResetSignal()
 
     # save statistics
     statistics["numSteps"] = numSteps
+    statistics["object"] = objectID
     self.statistics.append(statistics)
 
 
@@ -279,7 +283,8 @@ class L4L2Experiment(object):
     """
     plt.figure(0)
     stats = self.statistics[experimentID]
-    path = self.PLOT_DIRECTORY + self.name + "_exp_" + str(experimentID)
+    objectID = stats["object"]
+    initPath = self.PLOT_DIRECTORY + self.name + "_exp_" + str(experimentID)
 
     for i in xrange(self.numColumns):
       if onePlot:
@@ -301,16 +306,16 @@ class L4L2Experiment(object):
       plt.xticks(range(stats["numSteps"]))
       plt.ylabel("Number of active bits")
       plt.ylim(plt.ylim()[0] - 5, plt.ylim()[1] + 5)
-      plt.title("Object inference")
+      plt.title("Object inference for object {}".format(objectID))
 
       # save
       if not onePlot:
-        path = path + "_C" + str(i) + ".png"
+        path = initPath + "_C" + str(i) + ".png"
         plt.savefig(path)
         plt.close()
 
     if onePlot:
-      path = path + ".png"
+      path = initPath + ".png"
       plt.savefig(path)
       plt.close()
 
@@ -449,7 +454,7 @@ class L4L2Experiment(object):
       "permanenceDecrement": 0.02,
       "minThreshold": 10,
       "predictedSegmentDecrement": 0.004,
-      "activationThreshold": 13,
+      "activationThreshold": 10,
       "maxNewSynapseCount": 20,
       "monitor": 0,
       "implementation": "cpp",
@@ -465,7 +470,7 @@ class L4L2Experiment(object):
       "inputWidth": inputSize * 8,
       "learningMode": 1,
       "inferenceMode": 1,
-      "initialPermanence": 0.21,
+      "initialPermanence": 0.41,
       "connectedPermanence": 0.5,
       "permanenceIncrement": 0.1,
       "permanenceDecrement": 0.02,
@@ -475,7 +480,7 @@ class L4L2Experiment(object):
       "initialProximalPermanence": 0.6,
       "minThreshold": 10,
       "predictedSegmentDecrement": 0.004,
-      "activationThreshold": 13,
+      "activationThreshold": 10,
       "maxNewSynapseCount": 20,
     }
 

--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -231,6 +231,7 @@ class L4L2Experiment(object):
     patterns, can be given.
     """
     self._unsetLearningMode()
+    self._sendResetSignal()
 
     statistics = collections.defaultdict(list)
     objectID = inferenceConfig["object"]
@@ -254,7 +255,7 @@ class L4L2Experiment(object):
       self._updateInferenceStats(statistics, objectID)
 
     # send reset signal
-    # self._sendResetSignal()
+    self._sendResetSignal()
 
     # save statistics
     statistics["numSteps"] = numSteps
@@ -558,9 +559,8 @@ class L4L2Experiment(object):
     Sends a reset signal to the network.
     """
     for col in xrange(self.numColumns):
-      self.sensorInputs[col].addDataToQueue([], 1, 0)
-      self.externalInputs[col].addDataToQueue([], 1, 0)
-    self.network.run(1)
+      self.L4Columns[col].reset()
+      self.L2Columns[col].reset()
 
 
   def _addNoise(self, pattern, noiseLevel):

--- a/htmresearch/regions/ColumnPoolerRegion.py
+++ b/htmresearch/regions/ColumnPoolerRegion.py
@@ -332,6 +332,19 @@ class ColumnPoolerRegion(PyRegion):
     if lateralInput is not None:
       lateralInput = set(lateralInput.nonzero()[0])
 
+    # Handle reset first (should be sent with an empty signal)
+    if "resetIn" in inputs:
+      assert len(inputs["resetIn"]) == 1
+      if inputs["resetIn"][0] != 0:
+        # send empty output
+        self.reset()
+        self.activeState[:] = 0
+        outputs["feedForwardOutput"][:] = 0
+        outputs["activeCells"][:] = 0
+        outputs["predictiveCells"][:] = 0
+        outputs["predictedActiveCells"][:] = 0
+        return
+
     self._pooler.compute(
       feedforwardInput=feedforwardInput,
       activeExternalCells=lateralInput,
@@ -362,10 +375,10 @@ class ColumnPoolerRegion(PyRegion):
       raise Exception("Unknown outputType: " + self.defaultOutputType)
 
     # Handle reset after current input has been processed
-    if "resetIn" in inputs:
-      assert len(inputs["resetIn"]) == 1
-      if inputs["resetIn"][0] != 0:
-        self.reset()
+    # if "resetIn" in inputs:
+    #   assert len(inputs["resetIn"]) == 1
+    #   if inputs["resetIn"][0] != 0:
+    #     self.reset()
 
 
   def reset(self):

--- a/htmresearch/regions/ColumnPoolerRegion.py
+++ b/htmresearch/regions/ColumnPoolerRegion.py
@@ -327,23 +327,22 @@ class ColumnPoolerRegion(PyRegion):
     representation to this point and any history will then be reset. The output
     at the next compute will start fresh, presumably with bursting columns.
     """
-    feedforwardInput = inputs['feedforwardInput'].nonzero()[0]
-    lateralInput = inputs.get('lateralInput', None)
-    if lateralInput is not None:
-      lateralInput = set(lateralInput.nonzero()[0])
-
     # Handle reset first (should be sent with an empty signal)
     if "resetIn" in inputs:
       assert len(inputs["resetIn"]) == 1
       if inputs["resetIn"][0] != 0:
         # send empty output
         self.reset()
-        self.activeState[:] = 0
         outputs["feedForwardOutput"][:] = 0
         outputs["activeCells"][:] = 0
         outputs["predictiveCells"][:] = 0
         outputs["predictedActiveCells"][:] = 0
         return
+
+    feedforwardInput = inputs['feedforwardInput'].nonzero()[0]
+    lateralInput = inputs.get('lateralInput', None)
+    if lateralInput is not None:
+      lateralInput = set(lateralInput.nonzero()[0])
 
     self._pooler.compute(
       feedforwardInput=feedforwardInput,
@@ -374,15 +373,12 @@ class ColumnPoolerRegion(PyRegion):
     else:
       raise Exception("Unknown outputType: " + self.defaultOutputType)
 
-    # Handle reset after current input has been processed
-    # if "resetIn" in inputs:
-    #   assert len(inputs["resetIn"]) == 1
-    #   if inputs["resetIn"][0] != 0:
-    #     self.reset()
-
 
   def reset(self):
     """ Reset the state of the layer"""
+    self.activeState[:] = 0
+    self.previouslyPredictedCells[:] = 0
+
     if self._pooler is not None:
       self._pooler.reset()
 

--- a/htmresearch/regions/ExtendedTMRegion.py
+++ b/htmresearch/regions/ExtendedTMRegion.py
@@ -394,7 +394,6 @@ class ExtendedTMRegion(PyRegion):
       if inputs["resetIn"][0] != 0:
         # send empty output
         self.reset()
-        self.activeState[:] = 0
         outputs["feedForwardOutput"][:] = 0
         outputs["activeCells"][:] = 0
         outputs["predictiveCells"][:] = 0
@@ -442,15 +441,12 @@ class ExtendedTMRegion(PyRegion):
     else:
       raise Exception("Unknown outputType: " + self.defaultOutputType)
 
-    # Handle reset after current input has been processed
-    # if "resetIn" in inputs:
-    #   assert len(inputs["resetIn"]) == 1
-    #   if inputs["resetIn"][0] != 0:
-    #     self.reset()
-
 
   def reset(self):
     """ Reset the state of the TM """
+    self.activeState[:] = 0
+    self.previouslyPredictedCells[:] = 0
+
     if self._tm is not None:
       self._tm.reset()
       self.previouslyPredictedCells[:] = 0

--- a/htmresearch/regions/ExtendedTMRegion.py
+++ b/htmresearch/regions/ExtendedTMRegion.py
@@ -388,6 +388,19 @@ class ExtendedTMRegion(PyRegion):
     at the next compute will start fresh, presumably with bursting columns.
     """
 
+    # Handle reset first (should be sent with an empty signal)
+    if "resetIn" in inputs:
+      assert len(inputs["resetIn"]) == 1
+      if inputs["resetIn"][0] != 0:
+        # send empty output
+        self.reset()
+        self.activeState[:] = 0
+        outputs["feedForwardOutput"][:] = 0
+        outputs["activeCells"][:] = 0
+        outputs["predictiveCells"][:] = 0
+        outputs["predictedActiveCells"][:] = 0
+        return
+
     activeColumns = set(numpy.where(inputs["feedForwardInput"] == 1)[0])
 
     if "apicalInput" in inputs:
@@ -430,10 +443,10 @@ class ExtendedTMRegion(PyRegion):
       raise Exception("Unknown outputType: " + self.defaultOutputType)
 
     # Handle reset after current input has been processed
-    if "resetIn" in inputs:
-      assert len(inputs["resetIn"]) == 1
-      if inputs["resetIn"][0] != 0:
-        self.reset()
+    # if "resetIn" in inputs:
+    #   assert len(inputs["resetIn"]) == 1
+    #   if inputs["resetIn"][0] != 0:
+    #     self.reset()
 
 
   def reset(self):

--- a/htmresearch/regions/RawSensor.py
+++ b/htmresearch/regions/RawSensor.py
@@ -154,6 +154,21 @@ class RawSensor(PyRegion):
     })
 
 
+  def addResetToQueue(self, sequenceId):
+    """
+    Add a reset signal to the sensor's internal queue. Calls to compute
+    will cause items in the queue to be dequeued in FIFO order.
+
+    @param sequenceId An int or string with an integer ID associated with this
+                      token and its sequence (document).
+    """
+    self.queue.appendleft({
+      "sequenceId": int(sequenceId),
+      "reset": 1,
+      "nonZeros": [],
+    })
+
+
   def getOutputElementCount(self, name):
     """Returns the width of dataOut."""
 

--- a/projects/l2_pooling/multi_column.py
+++ b/projects/l2_pooling/multi_column.py
@@ -1,0 +1,195 @@
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+This file creates simple experiment to test a single column L4-L2 network.
+"""
+
+import random
+
+from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
+
+
+def runLateralDisambiguation(noiseLevel=None, profile=False):
+  """
+  Runs a simple experiment where two objects share a (location, feature) pair.
+  At inference, one column sees that ambiguous pair, and the other sees a
+  unique one. We should see the first column rapidly converge to a
+  unique representation.
+
+  :param noiseLevel: (float) Noise level to add to the locations and features
+                             during inference
+  :param profile:    (bool)  If True, the network will be profiled after
+                             learning and inference.
+
+  """
+  exp = L4L2Experiment(
+    "lateral_disambiguation",
+    numCorticalColumns=2,
+  )
+
+  objects = {}
+  objects = exp.addObject([(1, 1), (2, 2)], objects=objects)
+  objects = exp.addObject([(1, 1), (3, 2)], objects=objects)
+
+  exp.learnObjects(objects)
+  if profile:
+    exp.printProfile()
+
+  inferConfig = {
+    "object": 1,
+    "numSteps": 6,
+    "pairs": {
+      # this should activate 0 and 1
+      0: [(1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1)],
+      # this should activate 1
+      1: [(3, 2), (3, 2), (3, 2), (3, 2), (3, 2), (3, 2)]
+    }
+  }
+
+  exp.infer(inferConfig, noise=noiseLevel)
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"],
+    onePlot=False,
+  )
+
+
+
+def runDisambiguationByUnions(noiseLevel=None, profile=False):
+  """
+  Runs a simple experiment where an object is disambiguated as each column
+  recognizes a union of two objects, and the real object is the only
+  common one.
+
+  :param noiseLevel: (float) Noise level to add to the locations and features
+                             during inference
+  :param profile:    (bool)  If True, the network will be profiled after
+                             learning and inference.
+
+  """
+  exp = L4L2Experiment(
+    "disambiguation_unions",
+    numCorticalColumns=2,
+  )
+
+  objects = {}
+  objects = exp.addObject([(1, 1), (2, 2)], name=0, objects=objects)
+  objects = exp.addObject([(2, 2), (3, 3)], name=1, objects=objects)
+  objects = exp.addObject([(3, 3), (4, 4)], name=2, objects=objects)
+
+  exp.learnObjects(objects)
+  if profile:
+    exp.printProfile()
+
+  inferConfig = {
+    "object": 1,
+    "numSteps": 6,
+    "pairs": {
+      # this should activate 1 and 2
+      0: [(2, 2), (2, 2), (2, 2), (2, 2), (2, 2), (2, 2)],
+      # this should activate 2 and 3
+      1: [(3, 3), (3, 3), (3, 3), (3, 3), (3, 3), (3, 3)]
+    }
+  }
+
+  exp.infer(inferConfig, noise=noiseLevel)
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"],
+    onePlot=False,
+  )
+
+
+
+def runStretch(noiseLevel=None, profile=False):
+  """
+  Stretch test that learns a lot of objects.
+
+  :param noiseLevel: (float) Noise level to add to the locations and features
+                             during inference
+  :param profile:    (bool)  If True, the network will be profiled after
+                             learning and inference.
+
+  """
+  exp = L4L2Experiment(
+    "stretch",
+    numCorticalColumns=2,
+  )
+
+  objects = exp.createRandomObjects(10, 10)
+  print "Objects are:"
+  for object, pairs in objects.iteritems():
+    print str(object) + ": " + str(pairs)
+
+  exp.learnObjects(objects)
+  if profile:
+    exp.printProfile()
+
+  objectCopy1 = [pair for pair in objects[0]]
+  objectCopy2 = [pair for pair in objects[0]]
+  random.shuffle(objectCopy1)
+  random.shuffle(objectCopy2)
+
+  # stay multiple steps on each sensation
+  object1 = []
+  for pair in objectCopy1:
+    for _ in xrange(4):
+      object1.append(pair)
+
+  # stay multiple steps on each sensation
+  object2 = []
+  for pair in objectCopy2:
+    for _ in xrange(4):
+      object2.append(pair)
+
+  inferConfig = {
+    "object": 0,
+    "numSteps": len(object1),
+    "pairs": {
+      0: object1,
+      1: object2,
+    }
+  }
+
+  exp.infer(inferConfig, noise=noiseLevel)
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"],
+    onePlot=False,
+  )
+
+
+
+if __name__ == "__main__":
+  # basic experiment with lateral disambiguation
+  runStretch()

--- a/projects/l2_pooling/multi_column.py
+++ b/projects/l2_pooling/multi_column.py
@@ -189,7 +189,60 @@ def runStretch(noiseLevel=None, profile=False):
   )
 
 
+def runAmbiguities(noiseLevel=None, profile=False):
+  """
+  Runs a simple experiment where an object is disambiguated as each column
+  recognizes a union of two objects, and the real object is the only
+  common one.
+
+  :param noiseLevel: (float) Noise level to add to the locations and features
+                             during inference
+  :param profile:    (bool)  If True, the network will be profiled after
+                             learning and inference.
+
+  """
+  exp = L4L2Experiment(
+    "ambiguities",
+    numCorticalColumns=2,
+  )
+
+  objects = {}
+  objects = exp.addObject([(1, 1), (2, 1), (3, 3)], name=0, objects=objects)
+  objects = exp.addObject([(2, 2), (3, 3), (2, 1)], name=1, objects=objects)
+  objects = exp.addObject([(3, 1), (2, 1), (1, 2)], name=2, objects=objects)
+
+  exp.learnObjects(objects)
+  if profile:
+    exp.printProfile()
+
+  print exp.objectL2Representations
+
+  inferConfig = {
+    "object": 1,
+    "numSteps": 6,
+    "pairs": {
+      0: [(2, 1), (2, 1), (3, 3), (2, 2), (2, 2), (2, 2)],
+      1: [(3, 3), (3, 3), (3, 3), (2, 2), (2, 1), (2, 1)]
+    }
+  }
+
+  exp.infer(inferConfig, noise=noiseLevel)
+  if profile:
+    exp.printProfile()
+
+  exp.plotInferenceStats(
+    fields=["L2 Representation",
+            "Overlap L2 with object",
+            "L4 Representation"],
+    onePlot=False,
+  )
+
+  print exp.getInferenceStats(0)
+
+
 
 if __name__ == "__main__":
-  # basic experiment with lateral disambiguation
-  runStretch()
+  # runLateralDisambiguation()
+  # runDisambiguationByUnions()
+  # runStretch()
+  runAmbiguities()

--- a/projects/l2_pooling/multi_column.py
+++ b/projects/l2_pooling/multi_column.py
@@ -191,9 +191,9 @@ def runStretch(noiseLevel=None, profile=False):
 
 def runAmbiguities(noiseLevel=None, profile=False):
   """
-  Runs a simple experiment where an object is disambiguated as each column
-  recognizes a union of two objects, and the real object is the only
-  common one.
+  Runs an experiment where three objects are being learnt, but share many
+  patterns. At inference, only one object is being moved over, and we should
+  see quick convergence.
 
   :param noiseLevel: (float) Noise level to add to the locations and features
                              during inference
@@ -238,7 +238,7 @@ def runAmbiguities(noiseLevel=None, profile=False):
 
 
 if __name__ == "__main__":
-  # runLateralDisambiguation()
-  # runDisambiguationByUnions()
-  # runStretch()
-  runAmbiguities()
+  runLateralDisambiguation()
+  runDisambiguationByUnions(noiseLevel=0.05)
+  runStretch()
+  runAmbiguities(noiseLevel=0.05)

--- a/projects/l2_pooling/multi_column.py
+++ b/projects/l2_pooling/multi_column.py
@@ -215,8 +215,6 @@ def runAmbiguities(noiseLevel=None, profile=False):
   if profile:
     exp.printProfile()
 
-  print exp.objectL2Representations
-
   inferConfig = {
     "object": 1,
     "numSteps": 6,
@@ -236,8 +234,6 @@ def runAmbiguities(noiseLevel=None, profile=False):
             "L4 Representation"],
     onePlot=False,
   )
-
-  print exp.getInferenceStats(0)
 
 
 

--- a/projects/l2_pooling/single_column.py
+++ b/projects/l2_pooling/single_column.py
@@ -76,8 +76,6 @@ def runSharedFeatures(noiseLevel=None, profile=False):
   if profile:
     exp.printProfile()
 
-  print exp.statistics
-
   exp.plotInferenceStats(
     fields=["L2 Representation",
             "Overlap L2 with object",

--- a/tests/layers/laminar_network_test.py
+++ b/tests/layers/laminar_network_test.py
@@ -351,7 +351,7 @@ class LaminarNetworkTest(unittest.TestCase):
     L2RepresentationA = self.getCurrentL2Representation(L2Column)
     self.assertEqual(len(L2RepresentationA), 40)
 
-    for _ in xrange(3):
+    for _ in xrange(4):
       sensorInput.addDataToQueue(features[0], 0, 0)
       externalInput.addDataToQueue(locations[0], 0, 0)
       net.run(1)
@@ -380,8 +380,8 @@ class LaminarNetworkTest(unittest.TestCase):
     self.assertEqual(len(L4Representation00), 20)
 
     # send reset signal
-    sensorInput.addDataToQueue(features[1], 1, 0)
-    externalInput.addDataToQueue(locations[1], 0, 0)
+    sensorInput.addResetToQueue(0)
+    externalInput.addResetToQueue(0)
     net.run(1)
 
     # Object B
@@ -397,7 +397,7 @@ class LaminarNetworkTest(unittest.TestCase):
     # check that it is very different from object A
     self.assertLessEqual(len(L2RepresentationA & L2RepresentationB), 5)
 
-    for _ in xrange(3):
+    for _ in xrange(4):
       sensorInput.addDataToQueue(features[0], 0, 0)
       externalInput.addDataToQueue(locations[2], 0, 0)
       net.run(1)
@@ -434,8 +434,8 @@ class LaminarNetworkTest(unittest.TestCase):
     self.assertEqual(len(L4Representation11), 20)
 
     # send reset signal
-    sensorInput.addDataToQueue(features[1], 1, 0)
-    externalInput.addDataToQueue(locations[1], 0, 0)
+    sensorInput.addResetToQueue(0)
+    externalInput.addResetToQueue(0)
     net.run(1)
 
     # check inference with each (feature, location) pair
@@ -599,10 +599,10 @@ class LaminarNetworkTest(unittest.TestCase):
     self.assertEqual(len(L4Representation00_1), 20)
 
     # send reset signal
-    sensorInput0.addDataToQueue(features0[1], 1, 0)
-    externalInput0.addDataToQueue(locations0[1], 0, 0)
-    sensorInput1.addDataToQueue(features1[1], 1, 0)
-    externalInput1.addDataToQueue(locations1[1], 0, 0)
+    sensorInput0.addResetToQueue(0)
+    externalInput0.addResetToQueue(0)
+    sensorInput1.addResetToQueue(0)
+    externalInput1.addResetToQueue(0)
     net.run(1)
 
     # Object B
@@ -681,11 +681,10 @@ class LaminarNetworkTest(unittest.TestCase):
     self.assertEqual(len(L4Representation11_0), 20)
     self.assertEqual(len(L4Representation11_1), 20)
 
-    # send reset signal
-    sensorInput0.addDataToQueue(features0[1], 1, 0)
-    externalInput0.addDataToQueue(locations0[1], 0, 0)
-    sensorInput1.addDataToQueue(features1[1], 1, 0)
-    externalInput1.addDataToQueue(locations1[1], 0, 0)
+    sensorInput0.addResetToQueue(0)
+    externalInput0.addResetToQueue(0)
+    sensorInput1.addResetToQueue(0)
+    externalInput1.addResetToQueue(0)
     net.run(1)
 
     # check inference with each (feature, location) pair


### PR DESCRIPTION
This PR proposes a first set of multi-column L4-L2 experiments using the Network API the experiment framework proposed in #3. It also fixes a little problem in the reset logic in the regions used here, making sure that resets are sent with an empty signal and prevent calling the algorithms' `compute` methods and clears its outputs (to avoid sending erroneous lateral signals which are delayed).

It has four experiments:

- **Stretch** simply feeds a lot of objects and patterns to the network, for profiling purposes.

-  **Lateral disambiguation** is a simple experiment where two objects share a (location, feature) pair. At inference, one column sees that ambiguous pair, and the other sees a unique one. **Both sensors don't move during all inference.** We should see the first column rapidly converge to a unique representation.

<img src="https://s17.postimg.org/3q70wzb0v/lateral_disambiguation_exp_0_C0.png" width=325 /><img src="https://s17.postimg.org/pqnddltov/lateral_disambiguation_exp_0_C1.png" width=325 />

- **Disambiguation by unions** is an experiment where an object is disambiguated as each column recognizes a union of two objects, and the real object is the only common one. During inference, each columns keeps seeing the same (location, feature) pair, and the representations quickly converge thanks to lateral connections.

<img src="https://s17.postimg.org/g29xagyvj/disambiguation_unions_exp_0_C0.png" width=325 /><img src="https://s17.postimg.org/hilfsm1sf/disambiguation_unions_exp_0_C1.png" width=325 />

- **Ambiguities** is an experiment where three objects are learned by two cortical columns, each sharing many patterns. At inference, we feed each column with a sequence of random (location, feature) pairs, which all belong to the same object, and hope to see convergence.

<img src="https://s17.postimg.org/n2xx390nj/ambiguities_exp_0_C0.png" width=325 /><img src="https://s17.postimg.org/i5kci4yof/ambiguities_exp_0_C1.png" width=325 />


**Note:** On the last two experiments, 5% of spatial noise was added to the locations and features at inference.

**Note2:** on this last experiment, with different orders the L2 representation can spike up before converging.

@subutai 