### PR TITLE
 Serialize model parameters only using "save_dict"

### DIFF
--- a/nupic/research/frameworks/pytorch/cifar_experiment.py
+++ b/nupic/research/frameworks/pytorch/cifar_experiment.py
@@ -196,9 +196,9 @@ class TinyCIFAR(object):
     can be later passed to `model_restore()`.
     """
     # checkpoint_path = os.path.join(checkpoint_dir, "model.pth")
-    # torch.save(self.model.state_dict(), checkpoint_path)
+    # torch.save(self.model, checkpoint_path)
     checkpoint_path = os.path.join(checkpoint_dir, self.model_filename)
-    torch.save(self.model, checkpoint_path)
+    torch.save(self.model.state_dict(), checkpoint_path)
     return checkpoint_path
 
 
@@ -207,8 +207,9 @@ class TinyCIFAR(object):
     :param checkpoint_path: Loads model from this checkpoint path
     :return:
     """
-    self.model = torch.load(checkpoint_path, map_location=self.device)
-    # self.model.load_state_dict(checkpoint_path)
+    # self.model = torch.load(checkpoint_path, map_location=self.device)
+    checkpoint_file = os.path.join(checkpoint_path, self.model_filename)
+    self.model.load_state_dict(torch.load(checkpoint_file, map_location=self.device))
 
 
   def _createTestLoaders(self, noise_values):


### PR DESCRIPTION
@subutai This PR should fix the "save_dict" serialization.
I've tested using this code after training the 'quick' experiment:
```
   # Save trained TinyCIFAR model
    model.model_save(path)

    # Recreate TinyCIFAR model from serialized parameters
    serialized = TinyCIFAR()
    serialized.model_setup(config)
    serialized.model_restore(path)

    # Compare noise results
    expected = model._runNoiseTests(model.noise_values, model.test_loaders)
    actual = serialized._runNoiseTests(serialized.noise_values, serialized.test_loaders)
    print("expected:", expected)
    print("actual:", actual)
```

`nupic.torch` stores the **dutyCycle** and the **zeroWts** in registered buffers and save `state_dict ` should just work